### PR TITLE
Add code coverage analysis support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build_type: [Release]
+        build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
         include:
           - os: windows-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,11 @@
 {
+    "testing.coverageToolbarEnabled": true,
+    "cmake.coverageInfoFiles": [
+        "${workspaceFolder}/build/coverage_filtered.info"
+    ],
+    "cmake.preRunCoverageTarget": "lcov",
+    "cmake.postRunCoverageTarget": "genhtml",
+    "testing.defaultGutterClickAction": "runWithCoverage",
     "files.associations": {
         "*.h": "c"
     }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,13 @@ endif()
 
 # Add custom commands for code coverage analysis. Enable lcov and genhtml if
 # they are found. Only enable code coverage analysis for Debug build type, as it
-# is typically used for development and testing.
-# Note that code coverage analysis can add overhead to the build and runtime, so
-# it is generally not recommended for Release builds.
+# is typically used for development and testing. Code coverage analysis can add
+# overhead to the build and runtime, so it is generally not recommended for
+# Release builds.
 #
-# If lcov is found, add the necessary compiler and linker flags to enable code
+# If lcov is found, add the coverage compiler and linker flags to enable code
 # coverage analysis.
+#
 # Note that find_program will return the path to the executable if found, or
 # NOTFOUND if not found. It will also cache the result, so subsequent calls will
 # return the cached value. This allows us to check if lcov is available and
@@ -112,6 +113,9 @@ if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     )
     set_property(TARGET lcov PROPERTY FOLDER "Analysis")
 
+    # If genhtml is found, add a custom target to generate an HTML report from the
+    # filtered coverage data. This will create a coverage_report directory with an
+    # index.html file that can be opened in a web browser to view the coverage report.
     find_program(GENHTML genhtml)
     if(GENHTML)
         message(STATUS "lcov and genhtml found, code coverage targets will be available")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,11 @@ find_package(Doxygen OPTIONAL_COMPONENTS dot mscgen dia)
 if(DOXYGEN_FOUND)
     set(DOXYGEN_OPTIMIZE_OUTPUT_FOR_C YES)
     set(DOXYGEN_SOURCE_BROWSER YES)
-    doxygen_add_docs(doxy ${PROJECT_SOURCE_DIR}/inc ${PROJECT_SOURCE_DIR}/src)
+    doxygen_add_docs(doxy
+        ${PROJECT_SOURCE_DIR}/inc
+        ${PROJECT_SOURCE_DIR}/src
+        COMMENT "Generating API documentation with Doxygen"
+    )
 endif()
 
 # Add custom commands for code analysis. Enable cppcheck for Debug build type.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,46 @@ if(CPPCHECK AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 else()
     message(STATUS "Cppcheck not found or not enabled for Debug build type")
 endif()
+
+# Add custom commands for code coverage analysis. Enable lcov and genhtml if
+# they are found. Only enable code coverage analysis for Debug build type, as it
+# is typically used for development and testing.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    find_program(LCOV lcov)
+endif()
+
+# If lcov is found, add the necessary compiler and linker flags to enable code
+# coverage analysis.
+if(LCOV)
+    target_compile_options(phase_align PRIVATE --coverage)
+    target_compile_options(test_runner PRIVATE --coverage)
+    target_link_options(phase_align PRIVATE --coverage)
+    target_link_options(test_runner PRIVATE --coverage)
+
+    # Add custom targets for code coverage analysis using lcov and genhtml.
+    # These targets will run the tests, capture coverage data, and generate an HTML report.
+    add_custom_target(ctest
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+        DEPENDS test_runner
+    )
+    add_custom_target(lcov
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND ${LCOV} --capture --directory . --output-file coverage.info
+        COMMAND ${LCOV} --remove coverage.info '/usr/*' '*/test*' --output-file coverage_filtered.info
+        DEPENDS ctest
+    )
+
+    find_program(GENHTML genhtml)
+    if(GENHTML)
+        message(STATUS "lcov and genhtml found, code coverage targets will be available")
+        add_custom_target(genhtml
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMAND ${GENHTML} coverage_filtered.info --output-directory coverage_report
+            COMMAND ${CMAKE_COMMAND} -E echo "Coverage report generated in: ${CMAKE_BINARY_DIR}/coverage_report/index.html"
+            DEPENDS lcov
+        )
+    else()
+        message(STATUS "lcov and/or genhtml not found, code coverage targets will not be available")
+    endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_test(NAME le32 COMMAND test_runner test/le32)
 # https://www.mcternan.me.uk/mscgen/
 find_package(Doxygen OPTIONAL_COMPONENTS dot mscgen dia)
 if(DOXYGEN_FOUND)
-    set(OPTIMIZE_OUTPUT_FOR_C YES)
+    set(DOXYGEN_OPTIMIZE_OUTPUT_FOR_C YES)
     set(DOXYGEN_SOURCE_BROWSER YES)
     doxygen_add_docs(doxy ${PROJECT_SOURCE_DIR}/inc ${PROJECT_SOURCE_DIR}/src)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,6 @@ if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMAND ${LCOV} --capture --directory . --output-file coverage.info
         COMMAND ${LCOV} --remove coverage.info '/usr/*' '*/test*' --output-file coverage_filtered.info
-        DEPENDS ctest
     )
 
     find_program(GENHTML genhtml)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,17 @@ endif()
 # Add custom commands for code coverage analysis. Enable lcov and genhtml if
 # they are found. Only enable code coverage analysis for Debug build type, as it
 # is typically used for development and testing.
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    find_program(LCOV lcov)
-endif()
-
+# Note that code coverage analysis can add overhead to the build and runtime, so
+# it is generally not recommended for Release builds.
+#
 # If lcov is found, add the necessary compiler and linker flags to enable code
 # coverage analysis.
-if(LCOV)
+# Note that find_program will return the path to the executable if found, or
+# NOTFOUND if not found. It will also cache the result, so subsequent calls will
+# return the cached value. This allows us to check if lcov is available and
+# conditionally add code coverage targets.
+find_program(LCOV lcov)
+if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_options(phase_align PRIVATE --coverage)
     target_compile_options(test_runner PRIVATE --coverage)
     target_link_options(phase_align PRIVATE --coverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
         COMMAND ${LCOV} --capture --directory . --output-file coverage.info
         COMMAND ${LCOV} --remove coverage.info '/usr/*' '*/test*' --output-file coverage_filtered.info
     )
+    set_property(TARGET lcov PROPERTY FOLDER "Analysis")
 
     find_program(GENHTML genhtml)
     if(GENHTML)
@@ -116,6 +117,7 @@ if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
             COMMAND ${CMAKE_COMMAND} -E echo "Coverage report generated in: ${CMAKE_BINARY_DIR}/coverage_report/index.html"
             DEPENDS lcov
         )
+        set_property(TARGET genhtml PROPERTY FOLDER "Analysis")
     else()
         message(STATUS "genhtml not found, HTML code coverage report target will not be available")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,6 @@ if(LCOV AND CMAKE_BUILD_TYPE STREQUAL "Debug")
             DEPENDS lcov
         )
     else()
-        message(STATUS "lcov and/or genhtml not found, code coverage targets will not be available")
+        message(STATUS "genhtml not found, HTML code coverage report target will not be available")
     endif()
 endif()


### PR DESCRIPTION
Implement code coverage analysis using lcov and genhtml, enhancing testing capabilities in Debug mode. Configure VSCode to enable coverage toolbar and set up custom commands for running tests and generating HTML reports.